### PR TITLE
Fix NPE detecting classifiers on Linux

### DIFF
--- a/src/main/java/com/github/os72/protocjar/PlatformDetector.java
+++ b/src/main/java/com/github/os72/protocjar/PlatformDetector.java
@@ -113,11 +113,13 @@ public class PlatformDetector
 
             // If any of the requested classifier likes are found in the "likes" for this system,
             // append it to the classifier.
-            for (String classifierLike : classifierWithLikes) {
-                if (linuxRelease.like.contains(classifierLike)) {
-                    detectedClassifier += "-" + classifierLike;
-                    // First one wins.
-                    break;
+            if (classifierWithLikes != null) {
+                for (String classifierLike : classifierWithLikes) {
+                    if (linuxRelease.like.contains(classifierLike)) {
+                        detectedClassifier += "-" + classifierLike;
+                        // First one wins.
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Downloading protoc and plugins crashes on Linux because of this line in Protoc and ProtocJarMojo:

```
new PlatformDetector().detect(detectorProps, null);
```

Tested the fix and downloading the gRPC plugin works fine on Linux after this has been applied.