### PR TITLE
Fix temp file moving if tmp dir and source code are on different filesystems.

### DIFF
--- a/src/main/java/com/github/os72/protocjar/Protoc.java
+++ b/src/main/java/com/github/os72/protocjar/Protoc.java
@@ -122,6 +122,8 @@ public class Protoc
 				File tmpFile = null;
 				PrintWriter pw = null;
 				BufferedReader br = null;
+				FileInputStream is = null;
+				FileOutputStream os = null;
 				try {
 					tmpFile = File.createTempFile(file.getName(), null);
 					pw = new PrintWriter(tmpFile);
@@ -132,12 +134,21 @@ public class Protoc
 					}
 					pw.close();
 					br.close();
-					file.delete();
-					tmpFile.renameTo(file);
+					if (!file.delete()) {
+						log("Failed to delete " + file.getName());
+					}
+					is = new FileInputStream(tmpFile);
+					os = new FileOutputStream(file);
+					streamCopy(is, os);
+					if (!tmpFile.delete()) {
+						log("Failed to delete temporary file" + tmpFile.getName());
+					}
 				}
 				finally {
 					if (br != null) { try {br.close();} catch (Exception e) {} }
 					if (pw != null) { try {pw.close();} catch (Exception e) {} }
+					if (is != null) { try {is.close();} catch (Exception e) {} }
+					if (os != null) { try {os.close();} catch (Exception e) {} }
 				}
 			}
 		}

--- a/src/test/java/com/github/os72/protocjar/ProtocTest.java
+++ b/src/test/java/com/github/os72/protocjar/ProtocTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ProtocTest
 {
@@ -92,19 +93,26 @@ public class ProtocTest
 			new File(outDir).mkdirs();
 			String[] args = {"-v2.4.1", "--java_shaded_out="+outDir, sPersonSchemaFile};
 			assertEquals(0, Protoc.runProtoc(args));
+			assertHasGeneratedFile(outDir);
 		}
 		{
 			String outDir = "target/test-protoc-shaded-250";
 			new File(outDir).mkdirs();
 			String[] args = {"-v2.5.0", "--java_shaded_out="+outDir, sPersonSchemaFile};
 			assertEquals(0, Protoc.runProtoc(args));
+			assertHasGeneratedFile(outDir);
 		}
 		{
 			String outDir = "target/test-protoc-shaded-261";
 			new File(outDir).mkdirs();
 			String[] args = {"-v2.6.1", "--java_shaded_out="+outDir, sPersonSchemaFile};
 			assertEquals(0, Protoc.runProtoc(args));
+			assertHasGeneratedFile(outDir);
 		}
+	}
+
+	private static void assertHasGeneratedFile(String outDir) {
+		assertTrue(new File(outDir + "/com/github/os72/protocjar/PersonSchema.java").exists());
 	}
 
 	static final String sPersonSchemaFile = "src/test/resources/PersonSchema.proto";


### PR DESCRIPTION
File.renameTo() fails in such case.