### PR TITLE
set url connection timeouts and check for local maven cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target

--- a/src/main/java/com/github/os72/protocjar/Protoc.java
+++ b/src/main/java/com/github/os72/protocjar/Protoc.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -336,6 +337,8 @@ public class Protoc
 			log("downloading: " + srcUrl);
 			URLConnection con = srcUrl.openConnection();
 			con.setRequestProperty("User-Agent", "Mozilla"); // sonatype only returns proper maven-metadata.xml if this is set
+			con.setConnectTimeout(5000);
+			con.setReadTimeout(5000);
 			is = con.getInputStream();
 			os = new FileOutputStream(tmpFile);
 			streamCopy(is, os);
@@ -345,12 +348,13 @@ public class Protoc
 			destFile.delete();
 			tmpFile.renameTo(destFile);
 			destFile.setLastModified(System.currentTimeMillis());
-		}
-		catch (IOException e) {
+
+		} catch (SocketTimeoutException e) {
+			log(e);
+		} catch (IOException e) {
 			tmpFile.delete();
 			if (!destFile.exists()) throw e; // if download failed but had cached version, ignore exception
-		}
-		finally {
+		} finally {
 			if (is != null) is.close();
 			if (os != null) os.close();
 		}


### PR DESCRIPTION
This implementation may be not perfect because still don't support downloads to local maven cache, which is preferred to **protocjar.webcache** directory, but a little bit better. And timeouts are essential, otherwise tcp socket can hang for really long time.