### PR TITLE
Fix for broken multi-file shading with protoc 3.11.1

### DIFF
--- a/src/main/java/com/github/os72/protocjar/Protoc.java
+++ b/src/main/java/com/github/os72/protocjar/Protoc.java
@@ -149,8 +149,7 @@ public class Protoc
 				FileInputStream is = null;
 				FileOutputStream os = null;
 				try {
-					if (version.length() <= 5) version = version.replace(".", ""); // "1.2.3" -> "123"
-					else version = "_" + version.replace(".", "_"); // "3.11.1" -> "_3_11_1"
+					version = javaShadingVersion(version);
 					tmpFile = File.createTempFile(file.getName(), null);
 					pw = new PrintWriter(tmpFile);
 					br = new BufferedReader(new FileReader(file));
@@ -174,6 +173,16 @@ public class Protoc
 					if (tmpFile != null) tmpFile.delete();
 				}
 			}
+		}
+	}
+
+	static String javaShadingVersion(String version) {
+		if (!version.contains(".")) {
+			return version;
+		} else if (version.length() <= 5) {
+			return version.replace(".", ""); // "1.2.3" -> "123"
+		} else {
+			return "_" + version.replace(".", "_");
 		}
 	}
 

--- a/src/test/java/com/github/os72/protocjar/ProtocTest.java
+++ b/src/test/java/com/github/os72/protocjar/ProtocTest.java
@@ -15,9 +15,9 @@
  */
 package com.github.os72.protocjar;
 
-import java.io.File;
-
 import org.junit.Test;
+
+import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -98,6 +98,15 @@ public class ProtocTest
 			String[] args = {"-v2.4.1", "--java_out="+outDir, sPersonSchemaFile};
 			assertEquals(0, Protoc.runProtoc(args));
 		}
+	}
+
+	@Test
+	public void testJavaShadingVersion() {
+		log("testJavaShadingVersion");
+		assertEquals("123", Protoc.javaShadingVersion("1.2.3"));
+		assertEquals("123", Protoc.javaShadingVersion("123"));
+		assertEquals("_3_11_1", Protoc.javaShadingVersion("3.11.1"));
+		assertEquals("_3_11_1", Protoc.javaShadingVersion("_3_11_1"));
 	}
 
 	@Test


### PR DESCRIPTION
This provides a fix for https://github.com/os72/protoc-jar/issues/78

Split out production of the Java shading version formatting to make it more testable, add tests, and allow reformatting to be applied multiple times in situations where protoc generates multiple files or generates classes into a src path with other code to be repo-committed.

This isn't necessarily the most thorough fix, that would have to involve adding more test .proto files and more complex test suites, plus the code in Protoc still tries to reformat the version multiple times.

But this is the lightest-touch fix I could come up with while still adding unit tests to validate it.