### PR TITLE
Remove Mozilla user agent.

### DIFF
--- a/src/main/java/com/github/os72/protocjar/Protoc.java
+++ b/src/main/java/com/github/os72/protocjar/Protoc.java
@@ -327,7 +327,6 @@ public class Protoc
 		try {
 			log("downloading: " + srcUrl);
 			URLConnection con = srcUrl.openConnection();
-			con.setRequestProperty("User-Agent", "Mozilla"); // sonatype only returns proper maven-metadata.xml if this is set
 			con.setConnectTimeout(5000); // 5 sec timeout
 			con.setReadTimeout(5000); // 5 sec timeout
 			is = con.getInputStream();


### PR DESCRIPTION
The latest Artifactory redirects to UI if Mozilla user agent is set. https://www.jfrog.com/jira/browse/RTFACT-26216
OSS Sonatype seems to work now.