### PR TITLE
Increase the URL connection and read timeouts to 30 seconds

### DIFF
--- a/src/main/java/com/github/os72/protocjar/Protoc.java
+++ b/src/main/java/com/github/os72/protocjar/Protoc.java
@@ -328,8 +328,8 @@ public class Protoc
 			log("downloading: " + srcUrl);
 			URLConnection con = srcUrl.openConnection();
 			con.setRequestProperty("User-Agent", "Mozilla"); // sonatype only returns proper maven-metadata.xml if this is set
-			con.setConnectTimeout(5000); // 5 sec timeout
-			con.setReadTimeout(5000); // 5 sec timeout
+			con.setConnectTimeout(30000); // 30 sec timeout
+			con.setReadTimeout(30000); // 30 sec timeout
 			is = con.getInputStream();
 			os = new FileOutputStream(tmpFile);
 			streamCopy(is, os);


### PR DESCRIPTION
We are seeing situations when running in Docker that the protoc version download intermittently fails
and this breaks the CI build of our code.

It's not 100% clear from the log whether a timeout is what occurs given that we don't see why the download
fails in the logs, but I believe that a 5 seconds timeout can be pretty short if the network is held up by something else.

I think it should be a balanced value to increase this timeout to 30 seconds.
This will however slow down the fallback to pick up any cached version if the machine became offline.