### PR TITLE
fix extra _ while multi protoc Java Files generated.

### DIFF
--- a/src/main/java/com/github/os72/protocjar/Protoc.java
+++ b/src/main/java/com/github/os72/protocjar/Protoc.java
@@ -425,6 +425,7 @@ public class Protoc
 	}
 
 	static String getJavaShadingVersion(String version) {
+        if (!version.startsWith("_")) version = version.replaceFirst("_", "");
 		if (!version.contains(".")) return version;
 		else if (version.length() <= 5) return version.replace(".", ""); // "1.2.3" -> "123"
 		else return "_" + version.replace(".", "_"); // "3.11.1" -> "_3_11_1"


### PR DESCRIPTION
fix bug：
 remove extra _ while multi Java files generated.
 first Java class: extends _
 second: __
 third: ___