### PR TITLE
add support for riscv64

### DIFF
--- a/src/main/java/com/github/os72/protocjar/PlatformDetector.java
+++ b/src/main/java/com/github/os72/protocjar/PlatformDetector.java
@@ -217,6 +217,9 @@ public class PlatformDetector
         if ("s390x".equals(value)) {
             return "s390_64";
         }
+        if ("riscv64".equals(value)) {
+            return "riscv64";
+        }
 
         return UNKNOWN;
     }


### PR DESCRIPTION
solve the issue: https://github.com/os72/protoc-jar/issues/110

After test, this change can make it support the whole spark(v3.5.1)'s compiling.